### PR TITLE
Replace Fody.Costura to .NET Single-file app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,13 +25,11 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+    - name: Publish
+      run: dotnet publish -r win-x64
     - name: 'Artifacts'
       uses: actions/upload-artifact@v4
       with:
         name: Built program
         path: |
-          src/bin/Release/net8.0-windows
+          src/bin/Release/net8.0-windows/win-x64/publish

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -32,7 +32,7 @@ namespace PartyYomi
         // https://docs.microsoft.com/dotnet/core/extensions/logging
         private static readonly IHost _host = Host
             .CreateDefaultBuilder()
-            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(Assembly.GetEntryAssembly()!.Location)); })
+            .ConfigureAppConfiguration(c => { c.SetBasePath(Path.GetDirectoryName(AppContext.BaseDirectory)); })
             .ConfigureServices((context, services) =>
             {
                 services.AddHostedService<ApplicationHostService>();

--- a/src/FodyWeavers.xml
+++ b/src/FodyWeavers.xml
@@ -1,3 +1,0 @@
-﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura DisableCompression="true"/>
-</Weavers>

--- a/src/PartyYomi.csproj
+++ b/src/PartyYomi.csproj
@@ -6,6 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>wpfui-icon.ico</ApplicationIcon>
     <UseWPF>true</UseWPF>
+    <PublishSingleFile>true</PublishSingleFile>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/PartyYomi.csproj
+++ b/src/PartyYomi.csproj
@@ -8,7 +8,6 @@
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <DisableFody Condition="'$(Configuration)' == 'Debug'">true</DisableFody>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PartyYomi.csproj
+++ b/src/PartyYomi.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Costura.Fody" Version="5.7.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Lepo.i18n.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Lepo.i18n.Wpf" Version="2.0.0" />
     <PackageReference Include="MrAdvice" Version="2.15.0" />


### PR DESCRIPTION
Fixes #11 

Since the problem was from Fody.Costura, I've decided to replace it to [[dotnet Single File deployment](https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli)].

Also, replaced `Assembly.GetEntryAssembly()!.Location` to `AppContext.BaseDirectory` in `App.xaml.cs:35` since `Assembly.Location` will always return null when using `dotnet publish`.
For the detail, see https://github.com/dotnet/corert/issues/5467